### PR TITLE
* lib/clamav/client.rb : Configure with constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,19 +84,22 @@ client.execute(version_command)
 
 The default values in use are:
 
-  * clamd socket: UNIX Socket, located at `/tmp/clamd.socket`;
+  * clamd socket: UNIX Socket, located at `/var/run/clamav/clamd.ctl`;
   * New-line terminated commands.
 
-These defaults can be changed by injecting new values.
+These defaults can be changed:
 
-## Injecting dependencies
+  * by creating the object graph manually;
+  * by setting environment variables.
 
-### Client
+### The object graph
+
+#### Client
 
 The main object is the `Client` object. It is responsible for executing the commands.
 It can receive a custom connection object.
 
-### Connection
+#### Connection
 
 The `Connection` object is the bridge between the raw socket object and the
 protocol used between the client and the daemon.
@@ -108,12 +111,43 @@ protocol used between the client and the daemon.
 
 The management of those delimiters is done with the wrapper argument.
 
-### Wrapper
+#### Wrapper
 
 The wrapper is responsible for taking the incoming request with the
 `wrap_request` method, and parsing the response with the `read_response`
 method.
 
+### Environment variables
+
+The variables can be set programmatically in your Ruby programs like
+
+```ruby
+# from a ruby script
+ENV['CLAMD_UNIX_SOCKET'] = '/some/path'
+
+# Now the defaults are changed for any new ClamAV::Client instantiation
+```
+
+or by setting the variables before starting the Ruby process:
+
+```
+# from the command-line
+export CLAMD_UNIX_SOCKET = '/some/path'
+ruby my_program.rb
+# or
+CLAMD_UNIX_SOCKET = '/some/path' ruby my_program.rb
+```
+
+Please note that setting the `CLAMD_TCP_*` variables will have the precedence
+over the `CLAMD_UNIX_SOCKET`.
+
+#### CLAMD_UNIX_SOCKET
+
+Sets the socket path of the ClamAV daemon.
+
+#### CLAMD_TCP_HOST and CLAMD_TCP_PORT
+
+Sets the host and port of the ClamAV daemon.
 
 ## Contributing
 

--- a/lib/clamav/client.rb
+++ b/lib/clamav/client.rb
@@ -35,9 +35,18 @@ module ClamAV
 
     def default_connection
       ClamAV::Connection.new(
-        socket: ::UNIXSocket.new('/tmp/clamd.socket'),
+        socket: resolve_default_socket,
         wrapper: ::ClamAV::Wrappers::NewLineWrapper.new
       )
+    end
+
+    def resolve_default_socket
+      unix_socket, tcp_host, tcp_port = ENV.values_at('CLAMD_UNIX_SOCKET', 'CLAMD_TCP_HOST', 'CLAMD_TCP_PORT')
+      if tcp_host && tcp_port
+        ::TCPSocket.new(tcp_host, tcp_port)
+      else
+        ::UNIXSocket.new(unix_socket || '/var/run/clamav/clamd.ctl')
+      end
     end
   end
 end


### PR DESCRIPTION
Changing defaults was tedious. The object graph construction is now
dependent of some environment variables:
- CLAMD_UNIX_SOCKET
- CLAMD_TCP_HOST
- CLAMD_TCP_PORT

Any new client will benefit from these new options once those variables
are changed.

This closes #3.
