### PR TITLE
Add a configuration to custom max_chunk_size when using instream_command

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 3.2.1
+
+  * configure `max_chunk_size` in `InstreamCommand` by `CLAMAV_INSTREAM_MAX_CHUNK_SIZE` env
+
 # 3.2.0
 
   * Add `ClamAV::Client#ping` as a short-hand for executing a ping

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 # 3.2.1
 
-  * configure `max_chunk_size` in `InstreamCommand` by `CLAMAV_INSTREAM_MAX_CHUNK_SIZE` env
+  * Add a configuration to custom `max_chunk_size` in `InstreamCommand`
 
 # 3.2.0
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,20 @@ client.execute(ClamAV::Commands::InstreamCommand.new(io))
 # => [#<ClamAV::SuccessResponse:0x007fe471cabe50 @file="stream">]
 ```
 
+In the case you want to use a custom value of `max_chunk_size` in `InstreamCommand`, following the below:
+
+```ruby
+# clamav client config
+ClamAV::Client.config(instream_max_chunk_size: 2048)
+
+# Using the same above of INSTREAM
+client = ClamAV::Client.new
+
+io = StringIO.new('some data')
+client.execute(ClamAV::Commands::InstreamCommand.new(io))
+# => [#<ClamAV::SuccessResponse:0x007fe471cabe50 @file="stream">]
+```
+
 ### Custom commands
 
 Custom commands can be given to the client. The contract between the client

--- a/clamav-client.gemspec
+++ b/clamav-client.gemspec
@@ -3,7 +3,7 @@ $:<< 'lib'
 
 Gem::Specification.new do |spec|
   spec.name          = "clamav-client"
-  spec.version       = "3.2.0"
+  spec.version       = "3.2.1"
   spec.authors       = ["Franck Verrot"]
   spec.email         = ["franck@verrot.fr"]
   spec.summary       = %q{ClamAV::Client connects to a Clam Anti-Virus clam daemon and send commands.}

--- a/lib/clamav/client.rb
+++ b/lib/clamav/client.rb
@@ -26,7 +26,7 @@ require "clamav/wrappers/null_termination_wrapper"
 
 module ClamAV
   class Client
-    def self.config_clamav_client(instream_max_chunk_size:)
+    def self.config_client(instream_max_chunk_size:)
       @configuration = ClamAV::Configuration.new
 
       if instream_max_chunk_size

--- a/lib/clamav/client.rb
+++ b/lib/clamav/client.rb
@@ -25,8 +25,9 @@ require "clamav/wrappers/null_termination_wrapper"
 
 module ClamAV
   class Client
-    def initialize(connection = default_connection)
+    def initialize(connection = default_connection, configuration: Configuration.new)
       @connection = connection
+      @configuratin = configuration
       connection.establish_connection
     end
 
@@ -62,7 +63,7 @@ module ClamAV
     private
 
     def instream(io)
-      execute Commands::InstreamCommand.new(io)
+      execute Commands::InstreamCommand.new(io, @configuration)
     end
 
     def scan(file_path)

--- a/lib/clamav/client.rb
+++ b/lib/clamav/client.rb
@@ -77,7 +77,7 @@ module ClamAV
     private
 
     def instream(io)
-      execute Commands::InstreamCommand.new(io, @configuration.instream_max_chunk_size)
+      execute Commands::InstreamCommand.new(io)
     end
 
     def scan(file_path)

--- a/lib/clamav/client.rb
+++ b/lib/clamav/client.rb
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 require "clamav/connection"
+require "clamav/configuration"
 require "clamav/commands/ping_command"
 require "clamav/commands/quit_command"
 require "clamav/commands/scan_command"
@@ -27,7 +28,7 @@ module ClamAV
   class Client
     def initialize(connection = default_connection, configuration: Configuration.new)
       @connection = connection
-      @configuratin = configuration
+      @configuration = configuration
       connection.establish_connection
     end
 
@@ -63,7 +64,7 @@ module ClamAV
     private
 
     def instream(io)
-      execute Commands::InstreamCommand.new(io, @configuration)
+      execute Commands::InstreamCommand.new(io, @configuration.instream_max_chunk_size)
     end
 
     def scan(file_path)

--- a/lib/clamav/client.rb
+++ b/lib/clamav/client.rb
@@ -26,9 +26,22 @@ require "clamav/wrappers/null_termination_wrapper"
 
 module ClamAV
   class Client
-    def initialize(connection = default_connection, configuration: Configuration.new)
+    def self.config_clamav_client(instream_max_chunk_size:)
+      @configuration = ClamAV::Configuration.new
+
+      if instream_max_chunk_size
+        @configuration.instream_max_chunk_size = instream_max_chunk_size.to_i
+      end
+      @configuration
+    end
+
+    def self.configuration
+      @configuration || ClamAV::Configuration.new
+    end
+
+    def initialize(connection = default_connection)
       @connection = connection
-      @configuration = configuration
+      @configuration = ClamAV::Client.configuration
       connection.establish_connection
     end
 

--- a/lib/clamav/commands/instream_command.rb
+++ b/lib/clamav/commands/instream_command.rb
@@ -23,7 +23,7 @@ module ClamAV
 
       def initialize(io)
         @io = begin io rescue raise ArgumentError, 'io is required', caller; end
-        @max_chunk_size = ENV['CLAMAV_INSTREAM_MAX_CHUNK_SIZE'] || DEFAULT_MAX_CHUNK_SIZE
+        @max_chunk_size = (ENV['CLAMAV_INSTREAM_MAX_CHUNK_SIZE'] || DEFAULT_MAX_CHUNK_SIZE).to_i
       end
 
       def call(conn)

--- a/lib/clamav/commands/instream_command.rb
+++ b/lib/clamav/commands/instream_command.rb
@@ -19,11 +19,10 @@ require 'clamav/commands/command'
 module ClamAV
   module Commands
     class InstreamCommand < Command
-      DEFAULT_MAX_CHUNK_SIZE = 1024
 
-      def initialize(io)
+      def initialize(io, max_chunk_size = 1024)
         @io = begin io rescue raise ArgumentError, 'io is required', caller; end
-        @max_chunk_size = (ENV['CLAMAV_INSTREAM_MAX_CHUNK_SIZE'] || DEFAULT_MAX_CHUNK_SIZE).to_i
+        @max_chunk_size = max_chunk_size
       end
 
       def call(conn)

--- a/lib/clamav/commands/instream_command.rb
+++ b/lib/clamav/commands/instream_command.rb
@@ -20,7 +20,7 @@ module ClamAV
   module Commands
     class InstreamCommand < Command
 
-      def initialize(io, max_chunk_size = 1024)
+      def initialize(io, max_chunk_size = ClamAV::Client.configuration.instream_max_chunk_size)
         @io = begin io rescue raise ArgumentError, 'io is required', caller; end
         @max_chunk_size = max_chunk_size
       end

--- a/lib/clamav/commands/instream_command.rb
+++ b/lib/clamav/commands/instream_command.rb
@@ -19,10 +19,11 @@ require 'clamav/commands/command'
 module ClamAV
   module Commands
     class InstreamCommand < Command
+      DEFAULT_MAX_CHUNK_SIZE = 1024
 
-      def initialize(io, max_chunk_size = 1024)
+      def initialize(io)
         @io = begin io rescue raise ArgumentError, 'io is required', caller; end
-        @max_chunk_size = max_chunk_size
+        @max_chunk_size = ENV['CLAMAV_INSTREAM_MAX_CHUNK_SIZE'] || DEFAULT_MAX_CHUNK_SIZE
       end
 
       def call(conn)

--- a/lib/clamav/configuration.rb
+++ b/lib/clamav/configuration.rb
@@ -1,0 +1,11 @@
+module ClamAV
+  class Configuration
+    attr_reader :instream_max_chunk_size
+
+    DEFAULT_INSTREAM_MAX_CHUNK_SIZE = 1024
+
+    def initialize(instream_max_chunk_size: DEFAULT_INSTREAM_MAX_CHUNK_SIZE)
+      @instream_max_chunk_size = instream_max_chunk_size
+    end
+  end
+end

--- a/lib/clamav/configuration.rb
+++ b/lib/clamav/configuration.rb
@@ -1,6 +1,6 @@
 module ClamAV
   class Configuration
-    attr_reader :instream_max_chunk_size
+    attr_accessor :instream_max_chunk_size
 
     DEFAULT_INSTREAM_MAX_CHUNK_SIZE = 1024
 

--- a/test/integration/clamav/client_test.rb
+++ b/test/integration/clamav/client_test.rb
@@ -98,30 +98,25 @@ describe "ClamAV::Client Integration Tests" do
         end
 
         it "can recognize a sane file" do
-          command = build_command_for_file('innocent.txt', instream_max_chunk_size)
+          command = build_command_for_file('innocent.txt')
           client.execute(command).must_equal ClamAV::SuccessResponse.new("stream")
         end
 
         it "can recognize an infected file" do
-          command = build_command_for_file('clamavtest.txt', instream_max_chunk_size)
+          command = build_command_for_file('clamavtest.txt')
           client.execute(command).must_equal ClamAV::VirusResponse.new("stream", "ClamAV-Test-Signature")
         end
 
         it "can be used as #instream" do
           io = File.open(File.join(dir, 'innocent.txt'))
-          instream_command = ClamAV::Commands::InstreamCommand.new(io, instream_max_chunk_size)
+          instream_command = ClamAV::Commands::InstreamCommand.new(io)
           assert_equal client.execute(instream_command), client.send(:instream, io)
         end
       end
 
-      def build_command_for_file(file, instream_max_chunk_size = nil)
+      def build_command_for_file(file)
         io = File.open(File.join(dir, file))
-
-        if instream_max_chunk_size
-          ClamAV::Commands::InstreamCommand.new(io, instream_max_chunk_size)
-        else
-          ClamAV::Commands::InstreamCommand.new(io)
-        end
+        ClamAV::Commands::InstreamCommand.new(io)
       end
     end
 

--- a/test/integration/clamav/client_test.rb
+++ b/test/integration/clamav/client_test.rb
@@ -87,11 +87,14 @@ describe "ClamAV::Client Integration Tests" do
       end
 
       describe "instream_comment with custom instream_max_chunk_size" do
-        let(:dir) { File.expand_path('../../../../test/fixtures', __FILE__) }
         let(:instream_max_chunk_size) { 2048 }
 
         before do
-          ClamAV::Client.config_clamav_client(instream_max_chunk_size: 2048)
+          ClamAV::Client.config_clamav_client(instream_max_chunk_size: instream_max_chunk_size)
+        end
+
+        after do
+          ClamAV::Client.config_clamav_client(instream_max_chunk_size: 1024)
         end
 
         it "can recognize a sane file" do
@@ -115,9 +118,9 @@ describe "ClamAV::Client Integration Tests" do
         io = File.open(File.join(dir, file))
 
         if instream_max_chunk_size
-          ClamAV::Commands::InstreamCommand.new(io)
-        else
           ClamAV::Commands::InstreamCommand.new(io, instream_max_chunk_size)
+        else
+          ClamAV::Commands::InstreamCommand.new(io)
         end
       end
     end

--- a/test/integration/clamav/client_test.rb
+++ b/test/integration/clamav/client_test.rb
@@ -92,6 +92,37 @@ describe "ClamAV::Client Integration Tests" do
       end
     end
 
+    describe "instream_comment with custom instream_max_chunk_size" do
+      let(:dir) { File.expand_path('../../../../test/fixtures', __FILE__) }
+      let(:instream_max_chunk_size) { 2048 }
+      let(:client) {
+        ClamAV::Client.new(
+          configuration: ClamAV::Configuration.new(instream_max_chunk_size: instream_max_chunk_size)
+        )
+      }
+
+      it "can recognize a sane file" do
+        command = build_command_for_file('innocent.txt', instream_max_chunk_size)
+        client.execute(command).must_equal ClamAV::SuccessResponse.new("stream")
+      end
+
+      it "can recognize an infected file" do
+        command = build_command_for_file('clamavtest.txt', instream_max_chunk_size)
+        client.execute(command).must_equal ClamAV::VirusResponse.new("stream", "ClamAV-Test-Signature")
+      end
+
+      it "can be used as #instream" do
+        io = File.open(File.join(dir, 'innocent.txt'))
+        instream_command = ClamAV::Commands::InstreamCommand.new(io, instream_max_chunk_size)
+        assert_equal client.execute(instream_command), client.send(:instream, io)
+      end
+
+      def build_command_for_file(file, max_chunk_size)
+        io = File.open(File.join(dir, file))
+        ClamAV::Commands::InstreamCommand.new(io, max_chunk_size)
+      end
+    end
+
     describe 'safe?' do
       let(:dir) { File.expand_path('../../../../test/fixtures', __FILE__) }
 

--- a/test/integration/clamav/client_test.rb
+++ b/test/integration/clamav/client_test.rb
@@ -90,11 +90,11 @@ describe "ClamAV::Client Integration Tests" do
         let(:instream_max_chunk_size) { 2048 }
 
         before do
-          ClamAV::Client.config_clamav_client(instream_max_chunk_size: instream_max_chunk_size)
+          ClamAV::Client.config_client(instream_max_chunk_size: instream_max_chunk_size)
         end
 
         after do
-          ClamAV::Client.config_clamav_client(instream_max_chunk_size: 1024)
+          ClamAV::Client.config_client(instream_max_chunk_size: 1024)
         end
 
         it "can recognize a sane file" do

--- a/test/unit/clamav/commands/instream_command_test.rb
+++ b/test/unit/clamav/commands/instream_command_test.rb
@@ -36,27 +36,18 @@ describe "INSTREAM command" do
   end
 
   it "can specify the size of read chunks" do
-    mock_env("CLAMAV_INSTREAM_MAX_CHUNK_SIZE" => '1') do
-      @conn.expect(:write_request, nil, ["INSTREAM"])
-      @conn.expect(:raw_write, nil, ["\x00\x00\x00\x01h"])
-      @conn.expect(:raw_write, nil, ["\x00\x00\x00\x01e"])
-      @conn.expect(:raw_write, nil, ["\x00\x00\x00\x01l"])
-      @conn.expect(:raw_write, nil, ["\x00\x00\x00\x01l"])
-      @conn.expect(:raw_write, nil, ["\x00\x00\x00\x01o"])
-      @conn.expect(:raw_write, nil, ["\x00\x00\x00\x00"])
-      @conn.expect(:read_response, '1: stream: OK', [])
+    chunk_size = 1
 
-      assert ClamAV::Commands::InstreamCommand.new(@io).call(@conn)
-    end
-  end
+    @conn.expect(:write_request, nil, ["INSTREAM"])
+    @conn.expect(:raw_write, nil, ["\x00\x00\x00\x01h"])
+    @conn.expect(:raw_write, nil, ["\x00\x00\x00\x01e"])
+    @conn.expect(:raw_write, nil, ["\x00\x00\x00\x01l"])
+    @conn.expect(:raw_write, nil, ["\x00\x00\x00\x01l"])
+    @conn.expect(:raw_write, nil, ["\x00\x00\x00\x01o"])
+    @conn.expect(:raw_write, nil, ["\x00\x00\x00\x00"])
+    @conn.expect(:read_response, '1: stream: OK', [])
 
-  def mock_env(partial_env_hash)
-    old = ENV.to_hash
-    ENV.update partial_env_hash
-    begin
-      yield
-    ensure
-      ENV.replace old
-    end
+    assert ClamAV::Commands::InstreamCommand.
+      new(@io, chunk_size).call(@conn)
   end
 end


### PR DESCRIPTION
In the latest version, the `safe?` method does not have any options to configure `max_chunk_size.` So, I think it is not dynamic to use. Then, I see it better to configure `max_chunk_size ` as an ENV, but it also has a default value if ENV is nil value.
Please help me review this PR and add any comments. I will take the time to fix it. Thank you very much.