### PR TITLE
Add support for Ruby 3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,10 @@ jobs:
     <<: *shared
     environment:
       RUBY_VERSION=2.7-slim
+  "3.0":
+    <<: *shared
+    environment:
+      RUBY_VERSION=3.0
 
 workflows:
   version: 2
@@ -42,3 +46,4 @@ workflows:
       - "2.5"
       - "2.6"
       - "2.7"
+      - "3.0"


### PR DESCRIPTION
What do you think about Ruby 3.0 support?
I'm not sure about this repository's policy, but thought it's a good start point to run tests with Ruby 3.0 on CI.